### PR TITLE
Adds an example working (tested) Upstart service file and contributes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This plugin allows you to monitor your HAproxy loadbalancer. You can see the sta
 
 - New relic account, find our plugin in the plugin central
 - Python 2.7 with the python lib requests installed ( pip install requests // find the library directly into the OS's official repository // build it from the sources : http://www.python-requests.org/)
+  - Reports of it working on Python 2.6.6, however your mileage may vary and this is not supported.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,40 @@
-Monitoring pluging Haproxy python
+# Monitoring pluging Haproxy python
 
 This plugin allows you to monitor your HAproxy loadbalancer. You can see the state of your frontend (servers loadbalanced) and backend (HAproxy itself)
 
-Requirements
+### Requirements
 
 - New relic account, find our plugin in the plugin central
 - Python 2.7 with the python lib requests installed ( pip install requests // find the library directly into the OS's official repository // build it from the sources : http://www.python-requests.org/)
 
-Installation
+### Installation
 
 Create the newrelic conf directory if it is not created yet
-mkdir /etc/newrelic
+
+`mkdir /etc/newrelic`
 
 Copy the config file into this directory
-sudo cp agent-a0labs.cfg
+
+`sudo cp agent-a0labs.cfg /etc/newrelic/`
 
 Fill the informations in the cfg file:
-- Licence Key
+- License Key
 - URL to access the stat CSV Haproxy's file
 - user and password
 Optionnal:
 - enable/disable logs and specify the directory
 
-Now you are good to go, just launch the plugin and keep it running (daemon/nohup)
+### Daemonize
+There are a few ways to be sure the plugin remains running as a Daemon or service, some are better than others - but each should be selected based on your need.
 
-Support
+- use a nohup to launch it in background an detach it when you'll quit the terminal
+- use a crontab like "@reboot /usr/bin/python /path/to/bin"
+- put it in your /etc/init.d
+- use upstart
 
-Please use Github issues for support.
+./daemonize has some examples
+
+
+### Support
+
+Please useG [Github issues](https://github.com/Etherhypnos/agent-haproxy-a0labs/issues) for support.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are a few ways to be sure the plugin remains running as a Daemon or servic
 - put it in your /etc/init.d
 - use upstart
 
-./daemonize has some examples
+./daemonize has some examples, you should read their comments before trying to use the scripts
 
 
 ### Support

--- a/README.md
+++ b/README.md
@@ -17,11 +17,19 @@ Copy the config file into this directory
 
 `sudo cp agent-a0labs.cfg /etc/newrelic/`
 
+The python `requests` library is required:
+
+`pip install requests`
+
+If you chose to use a virtualenv, you may need to modify the example upstart/daemon scripts.
+
+
+
 Fill the informations in the cfg file:
 - License Key
 - URL to access the stat CSV Haproxy's file
 - user and password
-Optionnal:
+Optional:
 - enable/disable logs and specify the directory
 
 ### Daemonize

--- a/daemonize/agent-a0labs-newrelic.conf
+++ b/daemonize/agent-a0labs-newrelic.conf
@@ -1,6 +1,7 @@
 description "NewRelic HAProxy plugin by a0labs"
 author "a0labs https://github.com/Etherhypnos/agent-haproxy-a0labs"
 
+# /etc/init/agent-a0labs-newrelic.conf
 #
 # This is an upstart job to get your plugin running as a service
 # It expects your plugin to be in /usr/sbin

--- a/daemonize/agent-a0labs-newrelic.conf
+++ b/daemonize/agent-a0labs-newrelic.conf
@@ -1,0 +1,32 @@
+description "NewRelic HAProxy plugin by a0labs"
+author "a0labs https://github.com/Etherhypnos/agent-haproxy-a0labs"
+
+#
+# This is an upstart job to get your plugin running as a service
+# It expects your plugin to be in /usr/sbin
+# It also assumes you have installed the required pip modules
+# It does not account for a VirtualEnv (venv)
+# Remember to run initctl reload-configuration after editing this file
+#
+
+
+
+# Tune these settings to your needs
+start on runlevel [2345]
+stop on runlevel [015]
+
+
+script
+  LOGFILE=/var/log/agent-a0labs-newrelic.log
+
+  # This does not account for using a virtual environment (venv)
+  # Change to the full path of your venv binary if you are using one
+  exec /usr/bin/python /usr/sbin/agent-a0labs-newrelic >> $LOGFILE 2>&1
+
+  # If you want a non root user
+  # RUN_AS=username
+  # exec su - $RUN_AS "/usr/bin/python /usr/sbin/agent-a0labs-newrelic" >> $LOGFILE 2>&1
+end script
+
+# Only turn on respawn once you are done debugging and testing
+# respawn


### PR DESCRIPTION
In this branch I have worked out a functioning upstart file, tested on `Scientific Linux release 6.1 (Carbon)`.

The upstart file is placed in /etc/init/, folllowed by a `initctl reload-configuration` after which these commands should be available:

`status agent-a0labs-newrelic`

`start agent-a0labs-newrelic`

`stop agent-a0labs-newrelic`

Of course based on the users implementation of the haproxy plugin, that file may be modified to account for a venv or non-root user (small example included for non root user) 

---

Finally I cleaned up, marked down, and added to the README a bit. 
